### PR TITLE
Fix/dsp tcp command issues

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,10 @@
+---
+name: commitlint
+on: [push]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wagoid/commitlint-github-action@v5

--- a/README.md
+++ b/README.md
@@ -46,11 +46,3 @@ All releases must be versioned with the concept of semantic versioning:<br>
 v[Major].[Minor].[Patch]
 
 For more information, see [https://semver.org](https://semver.org).
-
-### Publish a new release
-There are a few steps to publish a release:
-1. Merge all changes to the master branch.
-2. The **last** change must include the new version number in the [Cargo.toml](Cargo.toml) file.
-3. Create the corresponding tag on github.
-4. The pipeline runs automatically when a new tag is pushed to the repository.<br>
-The pipeline builds the binaries and creates the release.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,3 @@ There are thrid party tools like Reaper, where you can set specific markers to t
 For light shows with the MaLighting GrandMa2, it is common practice to use the exported csv and import it to the console.<br>
 <br>
 I want to adapt this workflow to the Lasergraph DSP.
-
-## Releases
-
-### Semantic Versioning
-All releases must be versioned with the concept of semantic versioning:<br>
-v[Major].[Minor].[Patch]
-
-For more information, see [https://semver.org](https://semver.org).

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -6,6 +6,9 @@ use std::error::Error;
 use std::io::prelude::*;
 use std::net::TcpStream;
 
+// Define the TCP timeout in milliseconds
+const TCP_TIMEOUT: u64 = 100;
+
 fn replace_timestamp_last_colon_to_comma(input: &str) -> Result<String, Box<dyn Error>> {
     let split = input.split(':').collect::<Vec<&str>>();
 
@@ -89,6 +92,9 @@ fn send_timescript_and_entries(
         send_tcp_packet(stream, "")?;
 
         i += 1;
+
+        // Sleep for to prevent the DSP from crashing
+        std::thread::sleep(std::time::Duration::from_millis(TCP_TIMEOUT));
     }
 
     // Swtich to DSP main window
@@ -114,6 +120,9 @@ fn send_timescript(entries: Vec<Entry>, stream: &mut TcpStream) -> Result<(), Bo
         // Add timestamp to timescript
         send_tcp_packet(stream, &timescript_insert)?;
         send_tcp_packet(stream, "")?;
+
+        // Sleep for to prevent the DSP from crashing
+        std::thread::sleep(std::time::Duration::from_millis(TCP_TIMEOUT));
     }
 
     // Swtich to DSP main window
@@ -128,7 +137,6 @@ pub fn send(
     create_entries: bool,
     entry_offset: i32,
 ) -> Result<(), Box<dyn Error>> {
-    // Open TCP/IP stream
     let mut stream = TcpStream::connect(target)?;
     info!("TCP stream opened to address: {}", target);
 


### PR DESCRIPTION
This PR fixes an issue where the Lasergraph DSP cannot handle all incoming tcp commands.

We also introduce an automatic release with release-please.